### PR TITLE
send random video [review carefully]

### DIFF
--- a/bool_bot/google_drive_feat.py
+++ b/bool_bot/google_drive_feat.py
@@ -187,7 +187,7 @@ def get_folder_contents(query):
     return response["files"]
 
 
-def get_files_search(query):
+def get_files_search(query, video=False):
     """
     Get the files that contains the query. Matches it with file name. 
 
@@ -202,10 +202,14 @@ def get_files_search(query):
     folder_ids, folder_names = get_folder_ids(ROOT_PHOTO_FOLDER_ID)
     files = []
     found_files = []
+    gd_query = "'{}' in parents and trashed = false and (mimeType = 'image/jpeg' or mimeType = 'image/png' or mimeType = 'image/svg+xml')"
+
+    if video:
+        gd_query = "'{}' in parents and trashed = false and mimeType = 'video/mp4'"
 
     for id in folder_ids:
         page_token = None
-        response = service.files().list(q="'{}' in parents and trashed = false and (mimeType = 'image/jpeg' or mimeType = 'image/png' or mimeType = 'image/svg+xml')".format(id),
+        response = service.files().list(q=gd_query.format(id),
                                         pageSize=10,
                                         spaces="drive",
                                         fields='nextPageToken, files(id, name, webViewLink, description)',

--- a/bool_bot/index.py
+++ b/bool_bot/index.py
@@ -140,6 +140,12 @@ async def photo(ctx, search_option, query):
     else:
         await ctx.send("Something is wrong with your query, most likely that the option you provided is not valid")
 
+@bot.command(name="video")
+async def video(ctx, search_option, query):
+    if search_option == "r" or search_option == "random":
+        await video_random(ctx, query)
+
+
 @bot.command(name="listrequests")
 async def list_requests(ctx):
     """
@@ -449,6 +455,43 @@ async def channel_remove(ctx, name):
         return await ctx.send("Sucessfully remove bot from {0} text channel".format(name))
 
     return await ctx.send("Cannot find channel {0}".format(name))
+
+# ================================================================================
+# Video functions
+async def video_random(ctx, query):
+    found_files = google_drive_feat.get_files_search(query, video=True)
+    
+    if len(found_files) == 0:
+        await ctx.send("No random video found, probably because there are no video names with the query you requested")
+        return
+
+    
+    random_index = random.randint(0, len(found_files) - 1)
+    random_file_id = found_files[random_index]["id"]
+    random_file_name = found_files[random_index]["name"]
+    
+    await send_video(ctx, random_file_id, random_file_name)
+
+async def send_video(ctx, file_id, file_name):
+    """
+    Works exactly the same way as send_photo, but without the embed since you can't embed videos with discord.py(I may be wrong)
+    """
+
+    video_name = google_drive_feat.download_photo(file_id, file_name) # maybe change the name of download_photo to download_file?
+
+    # Reads file from local storage
+    buffered = open(temp_dir + video_name, "rb")
+    file_video = discord.File(buffered, filename=video_name)
+    # insert embed code here, if possible
+
+    await ctx.send("Sending Video", file=file_video)
+
+    buffered.close()
+
+    # Deletes file from local storage
+    os.remove(temp_dir + video_name)
+
+    return
 
 def main():
     """

--- a/bool_bot/index.py
+++ b/bool_bot/index.py
@@ -142,6 +142,13 @@ async def photo(ctx, search_option, query):
 
 @bot.command(name="video")
 async def video(ctx, search_option, query):
+    """
+    Video commands. 
+
+    Flags
+
+    r or random - Searches for a video with query and return a random one. Ex. !video r jey
+    """
     if search_option == "r" or search_option == "random":
         await video_random(ctx, query)
 
@@ -459,6 +466,11 @@ async def channel_remove(ctx, name):
 # ================================================================================
 # Video functions
 async def video_random(ctx, query):
+    """
+    Gets a random video based off of query. Searches for video name and in its description
+
+    query : String - The video name or description.  
+    """
     found_files = google_drive_feat.get_files_search(query, video=True)
     
     if len(found_files) == 0:


### PR DESCRIPTION
changes to get_file_search:
- new default flag depending on whether video or photo files are requested
- new video query added, and used depending on value of flag

changes to index.py:
- new video command, invoked via !video
- only option right now is "r" or "random", which works exactly like it does with photo command
- 2 new functions specifically for videos, video_random and send_video
- video_random -> works like photo_random
- send_video -> works like send_photo, without the embed since discord.py doesn't support video embeds, but might be a way around that. might change this to just use send_photo instead since the code is more or less the same but i just realized that as i was typing this
- sends only mp4 videos for now

review carefully, just an initial feature for videos. can add more options later.